### PR TITLE
Wrap in a closure to prevent exposing 'module' to the global scope

### DIFF
--- a/nzSweetAlert.js
+++ b/nzSweetAlert.js
@@ -1,39 +1,44 @@
-var module = angular.module('nzSweetAlert', []);
+(function (window, angular) {
 
-module.factory('nzSwal', ['$q',
-    function($q) {
-        if (!window.swal) {
-            console.log('Sweet Alert is not loaded!');
-            return;
-        }
+    var module = angular.module('nzSweetAlert', []);
 
-        return service;
-
-        function service(p1, p2, p3) {
-
-            var deferred = $q.defer();
-
-            var params;
-
-            if (typeof p1 !== 'object') {
-                params = {
-                    title: p1 ? p1 : '',
-                    text: p2 ? p2 : '',
-                    type: p3 ? p3 : null,
-                };
-            } else {
-                params = p1;
+    module.factory('nzSwal', ['$q',
+        function($q) {
+            if (!window.swal) {
+                console.log('Sweet Alert is not loaded!');
+                return;
             }
 
-            swal(params, function(isConfirm) {
-                if (isConfirm) {
-                    deferred.resolve();
-                } else {
-                    deferred.reject();
-                }
-            });
+            return service;
 
-            return deferred.promise;
+            function service(p1, p2, p3) {
+
+                var deferred = $q.defer();
+
+                var params;
+
+                if (typeof p1 !== 'object') {
+                    params = {
+                        title: p1 ? p1 : '',
+                        text: p2 ? p2 : '',
+                        type: p3 ? p3 : null,
+                    };
+                } else {
+                    params = p1;
+                }
+
+                swal(params, function(isConfirm) {
+                    if (isConfirm) {
+                        deferred.resolve();
+                    } else {
+                        deferred.reject();
+                    }
+                });
+
+                return deferred.promise;
+            }
         }
-    }
-]);
+    ]);
+
+
+})(window, window.angular);


### PR DESCRIPTION
Wrapping code in closures is a good practice in JavaScript, specially when writing code that will run on a browser.
In this case, `module` would be exposed globally and that might cause incompatibilities with other packages, since some of them are built using browserify, which also exposes a `module` variable in order to export its modules (similar to Node.js module framework).
[Here's an example](https://github.com/getsentry/raven-js/blob/759cfafa809011fffab59294310649dc15be9bc3/dist/raven.js#L1853) of what would happen.
